### PR TITLE
Strip trailing spaces from email adresses

### DIFF
--- a/lib/member_page.rb
+++ b/lib/member_page.rb
@@ -24,5 +24,6 @@ class MemberPage < Scraped::HTML
         .last
         .xpath('following-sibling::td')
         .text
+        .tidy
   end
 end

--- a/test/data/251.yml
+++ b/test/data/251.yml
@@ -4,5 +4,4 @@
 :to_h:
   :name: Héctor Ulises Cristopulos Ríos
   :image: http://sitl.diputados.gob.mx/LXIII_leg/fotos_lxiiiconfondo/088_FOTO_CHICA.jpg
-  # TODO: The trailing space should be removed (issue: #7)
-  :email: 'hector.cristopulos@congreso.gob.mx '
+  :email: 'hector.cristopulos@congreso.gob.mx'


### PR DESCRIPTION
Email addresses were coming with a trailing space. Make sure we `tidy` them.

Fixes https://github.com/everypolitician-scrapers/mexico-diputados-2015/issues/7